### PR TITLE
Fix morizon keymap errors and update board name for Zephyr 4.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -13,19 +13,19 @@
 #
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano_v2/nrf52840/zmk
     shield: horizon
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano_v2/nrf52840/zmk
     shield: morizon
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano_v2/nrf52840/zmk
     shield: fract
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano_v2/nrf52840/zmk
     shield: tackle
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y

--- a/build.yaml
+++ b/build.yaml
@@ -13,19 +13,19 @@
 #
 ---
 include:
-  - board: nice_nano_v2/nrf52840/zmk
+  - board: nice_nano
     shield: horizon
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2/nrf52840/zmk
+  - board: nice_nano
     shield: morizon
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2/nrf52840/zmk
+  - board: nice_nano
     shield: fract
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2/nrf52840/zmk
+  - board: nice_nano
     shield: tackle
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y


### PR DESCRIPTION
## Summary

- Fix `&RBRC` undefined reference → `&kp RBRC` (compile error)
- Remove duplicate `#include` directives in `morizon.keymap`
- Remove `ext_power` bindings and config (no LEDs/screen on this board)
- Fix `NUMBER_3` → `N3` for consistency
- Remove deprecated `label` property from kscan node in overlay
- Update board name `nice_nano_v2` → `nice_nano` (ZMK Zephyr 4.1 rename)

https://claude.ai/code/session_01UPekCznAzHGfGkinsQZwBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPekCznAzHGfGkinsQZwBh)_